### PR TITLE
Set old Stripe API version so pagination isn't broken

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ function Cohorter (key, options) {
   if (!(this instanceof Cohorter)) return new Cohorter(key, options);
   if (!key) throw new Error('Stripe cohort requires a Stripe key.');
   this.stripe = Stripe(key);
+  this.stripe.setApiVersion('2014-03-13');
   this.options = defaults(options, { count: 100, concurrency: 1 });
   var self = this;
   return function () { self.cohort.apply(self, arguments); };


### PR DESCRIPTION
Fixes #3

After this version of Stripe's API they removed the `count` property that the pagination here currently relies upon. So the easiest solution is to just keep using the old API version.

https://stripe.com/docs/upgrades#2014-03-28